### PR TITLE
Adding more help

### DIFF
--- a/docs/pages/_en/beta/guides/rir-csharp.md
+++ b/docs/pages/_en/beta/guides/rir-csharp.md
@@ -64,7 +64,8 @@ using UI = Autodesk.Revit.UI;
 
 {{ site.terms.rir }} provides a few utility methods as well. Later on this guide, we are going to use one of these utility functions to bake a sphere into a Revit model. To access these methods, we need to add another binding to `RhinoInside.Revit.dll` assembly which is shipped with {{ site.terms.rir }}.
 
-Please follow the steps described above, and add a reference to this assembly as well. You can find the DLL under `%APPDATA%/Autodesk/Revit/Addins/XXXX/RhinoInside.Revit/` where `XXXX` is the Revit version e.g. `2019`
+Please follow the steps described above, and add a reference to this assembly as well. Typically, you can find the DLL under `%APPDATA%/Autodesk/Revit/Addins/XXXX/RhinoInside.Revit/` where `XXXX` is the Revit version e.g. `2019`
+In some cases, (such as if system admin has installed this addon) it may be under %PROGRAMDATA%/Autodesk/Revit/20XX/RhinoInside.Revit
 
 ![]({{ "/static/images/guides/rir-csharp04b.png" | prepend: site.baseurl }})
 


### PR DESCRIPTION
As described on this thread: https://discourse.mcneel.com/t/revit-cannot-run-rhino-inside/109424
Sometimes the RhinoInside.Revit.dll file will be in a different location, adding that info to the help docs.